### PR TITLE
[POC] Programmically create Ethereum wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ export const INITIAL_STATE: IAppState = {
   },
   connected: false,
   chainId: getAppConfig().chainId || DEFAULT_CHAIN_ID,
+  // TODO: simplify accounts, address, activeIndex since there is only 1 account
   address: DEFAULT_ADDRESS,
   requests: [],
   results: [],
@@ -174,49 +175,11 @@ class App extends React.Component<{}> {
     this.init();
   };
 
-  public initWalletConnect = async () => {
-    const { uri } = this.state;
-
-    this.setState({ loading: true });
-
-    try {
-      const connector = new WalletConnect({ uri });
-
-      if (!connector.connected) {
-        await connector.createSession();
-      }
-
-      await this.setState({
-        loading: false,
-        connector,
-        uri: connector.uri,
-      });
-
-      this.subscribeToEvents();
-    } catch (error) {
-      this.setState({ loading: false });
-
-      throw error;
-    }
-  };
-
-  public onURIPaste = async (e: any) => {
-    const data = e.target.value;
-    const uri = typeof data === "string" ? data : "";
-    if (uri) {
-      await this.setState({ uri });
-      await this.initWalletConnect();
-    }
-  };
-
 
   public render() {
     return (
       <>
-        <div>
-          {this.state.address}
-        </div>
-        <input onChange={this.onURIPaste} placeholder="Paste wc uri"></input>
+        Hi
       </>
     )
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,7 +179,7 @@ class App extends React.Component<{}> {
   public render() {
     return (
       <>
-        Hi
+        {DEFAULT_ADDRESS}
       </>
     )
   }

--- a/src/controllers/wallet.ts
+++ b/src/controllers/wallet.ts
@@ -2,6 +2,7 @@ import * as ethers from "ethers";
 import * as ethSigUtil from "eth-sig-util";
 import { getChainData } from "../helpers/utilities";
 import { 
+  DEFAULT_ACTIVE_INDEX,
   DEFAULT_CHAIN_ID
  } from "../constraints/default";
 import { getAppConfig } from "../config";


### PR DESCRIPTION
## PR description
**BLUF:** Used ethers.js to create wallet, store the mnemonic so that the system can instantiate the same wallet everytime

In this pull request, I created a POC to programmatically create an ethereum wallet address as a public treasury using `ethers.js`

As a POC, the mnemonic used to initiate the Ethereum wallet is stored as an environmental variable. In the actual application, the mnemonics will be stored in the database so that when user authenticates, the system can pull the mnemonic out and initiate the same wallet every single time.

## Ethereum engines
In order to facilitate for the basic blockchain operations, I also took the code from [WalletConnect test wallet example](https://github.com/WalletConnect/walletconnect-test-wallet). The code are in `/engines`

## UI
<img width="549" alt="Screenshot 2022-10-02 at 5 49 43 PM" src="https://user-images.githubusercontent.com/15060312/193475646-86cf8c8b-30e3-4f44-a271-0d4263d93c75.png">
