### PR TITLE
[POC] Use club wallet to connect dApps + Sign transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",
         "@walletconnect/client": "^1.8.0",
+        "axios": "^0.27.2",
         "eth-sig-util": "^3.0.1",
         "ethers": "^5.6.8",
         "magic-sdk": "^9.0.0",
@@ -3732,6 +3733,14 @@
         "@ethersproject/abstract-signer": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/properties": "^5.5.0"
+      }
+    },
+    "node_modules/@gnosis.pm/safe-ethers-adapters/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/@gnosis.pm/safe-ethers-lib": {
@@ -8597,15 +8606,6 @@
         "arweave": "^1.10.0"
       }
     },
-    "node_modules/arweave/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -8814,11 +8814,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -30070,6 +30071,16 @@
         "@gnosis.pm/safe-core-sdk-types": "^1.1.0",
         "@gnosis.pm/safe-deployments": "^1.12.0",
         "axios": "^0.26.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
       }
     },
     "@gnosis.pm/safe-ethers-lib": {
@@ -33969,17 +33980,6 @@
         "base64-js": "^1.5.1",
         "bignumber.js": "^9.0.2",
         "util": "^0.12.4"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        }
       }
     },
     "arweave-stream-tx": {
@@ -34145,11 +34145,12 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "axobject-query": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.5",
     "@walletconnect/client": "^1.8.0",
+    "axios": "^0.27.2",
     "eth-sig-util": "^3.0.1",
     "ethers": "^5.6.8",
     "magic-sdk": "^9.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,10 @@
 import * as React from "react";
-import WalletConnect from "@walletconnect/client";
 import { getAppControllers } from "./controllers";
 import { getAppConfig } from "./config";
 import { DEFAULT_CHAIN_ID, DEFAULT_ACTIVE_INDEX } from "./constraints/default";
 import { getCachedSession } from "./helpers/utilities";
-
-export interface IAppState {
-  loading: boolean;
-  scanner: boolean;
-  connector: WalletConnect | null;
-  uri: string;
-  peerMeta: {
-    description: string;
-    url: string;
-    icons: string[];
-    name: string;
-    ssl: boolean;
-  };
-  connected: boolean;
-  chainId: number;
-  address: string;
-  requests: any[];
-  results: any[];
-  payload: any;
-}
+import { IAppState } from "./helpers/types";
+import WalletConnect from "@walletconnect/client";
 
 export const DEFAULT_WALLET = getAppControllers().wallet.getWallet();
 export const DEFAULT_ACCOUNTS = [DEFAULT_WALLET.address];
@@ -67,6 +48,8 @@ class App extends React.Component<{}> {
   public init = async () => {
     let { chainId } = this.state;
 
+    // TODO: Modify how/what we store in localStorage for the cache
+    // NOTE: the connector is stored in localStorage once connected
     const session = getCachedSession();
 
     if (!session) {
@@ -92,13 +75,14 @@ class App extends React.Component<{}> {
 
       this.subscribeToEvents();
     }
+    localStorage.setItem("MNEMONIC",String(process.env.REACT_APP_MNEMONIC));
     await getAppConfig().events.init(this.state, this.bindedSetState);
   };
 
   public bindedSetState = (newState: Partial<IAppState>) =>
     this.setState(newState);
 
-  // NOTES: Subscribing to the different events emitted by the connector
+  // HELPER FUNCTION: call this subscribe function to confirm the type of event emitted by connector
   public subscribeToEvents = () => {
     console.log("ACTION", "subscribeToEvents");
     const { connector } = this.state;
@@ -127,6 +111,7 @@ class App extends React.Component<{}> {
         // tslint:disable-next-line
         console.log("EVENT", "call_request", "method", payload.method);
         console.log("EVENT", "call_request", "params", payload.params);
+        console.log("PAYLOAD", payload);
 
         if (error) {
           throw error;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,6 +224,47 @@ class App extends React.Component<{}> {
     }
   };
 
+  public approveRequest = async () => {
+    const { connector, payload } = this.state;
+
+    try {
+      await getAppConfig().rpcEngine.signer(payload, this.state, this.bindedSetState);
+    } catch (error) {
+      console.error(error);
+      if (connector) {
+        connector.rejectRequest({
+          id: payload.id,
+          error: { message: "Failed or Rejected Request" },
+        });
+      }
+    }
+
+    this.closeRequest();
+    await this.setState({ connector });
+  };
+
+  public rejectRequest = async () => {
+    const { connector, payload } = this.state;
+    if (connector) {
+      connector.rejectRequest({
+        id: payload.id,
+        error: { message: "Failed or Rejected Request" },
+      });
+    }
+    await this.closeRequest();
+    await this.setState({ connector });
+  };
+
+  public closeRequest = async () => {
+    const { requests, payload } = this.state;
+    const filteredRequests = requests.filter(request => request.id !== payload.id);
+    await this.setState({
+      requests: filteredRequests,
+      payload: null,
+    });
+  };
+
+
   public render() {
     const { peerMeta, connected, requests, payload } = this.state;
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,7 @@ class App extends React.Component<{}> {
   };
 
   public render() {
-    const {peerMeta, connected} = this.state;
+    const {peerMeta, connected, requests, payload} = this.state;
     return (
       <>
         <div>{this.state.address}</div>
@@ -246,10 +246,25 @@ class App extends React.Component<{}> {
               <img src={peerMeta.icons[0]} alt={peerMeta.name} />
               <div>{peerMeta.name}</div>
               <button onClick={this.killSession}>Disconnect</button>
+              {!payload ? (
+                requests.length !== 0 && (
+                  <div>
+                    {requests.map((request,index) => (
+                      <div key={index}>
+                        <p>{request.method}</p>
+                        <button onClick={() => this.setState({payload: request}) }>Sign</button>
+                      </div>
+                    ))}
+                  </div>
+                )
+              ) : (
+                <div>
+                  this is payload
+                </div>
+              )}
             </>
           )
         }
-        
         <div></div>
       </>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_CHAIN_ID, DEFAULT_ACTIVE_INDEX } from "./constraints/default";
 import { getCachedSession } from "./helpers/utilities";
 import { IAppState } from "./helpers/types";
 import WalletConnect from "@walletconnect/client";
+import { Payload } from "./components/Payload";
 
 export const DEFAULT_WALLET = getAppControllers().wallet.getWallet();
 export const DEFAULT_ACCOUNTS = [DEFAULT_WALLET.address];
@@ -75,7 +76,7 @@ class App extends React.Component<{}> {
 
       this.subscribeToEvents();
     }
-    localStorage.setItem("MNEMONIC",String(process.env.REACT_APP_MNEMONIC));
+    localStorage.setItem("MNEMONIC", String(process.env.REACT_APP_MNEMONIC));
     await getAppConfig().events.init(this.state, this.bindedSetState);
   };
 
@@ -165,7 +166,6 @@ class App extends React.Component<{}> {
     this.init();
   };
 
-
   public initWalletConnect = async () => {
     const { uri } = this.state;
 
@@ -189,7 +189,6 @@ class App extends React.Component<{}> {
 
       // Call the event subscriber to get to know what is the event emitted by connector
       this.subscribeToEvents();
-
     } catch (error) {
       this.setState({ loading: false });
 
@@ -226,45 +225,54 @@ class App extends React.Component<{}> {
   };
 
   public render() {
-    const {peerMeta, connected, requests, payload} = this.state;
+    const { peerMeta, connected, requests, payload } = this.state;
+    
     return (
       <>
         <div>{this.state.address}</div>
         <input onChange={this.onURIPaste} placeholder="Paste wc uri"></input>
         <br></br>
-        {!connected ? 
-          (peerMeta && peerMeta.name && (
+        {!connected ? (
+          // View to connect to dApp
+          peerMeta &&
+          peerMeta.name && (
             <>
               <p>{peerMeta.name}</p>
               <p>{peerMeta.description}</p>
               <button onClick={this.approveSession}>Approve</button>
               <button>Rejects</button>
             </>
-          )) : (
-            <>
-              <h6>{"Connected to"}</h6>
-              <img src={peerMeta.icons[0]} alt={peerMeta.name} />
-              <div>{peerMeta.name}</div>
-              <button onClick={this.killSession}>Disconnect</button>
-              {!payload ? (
-                requests.length !== 0 && (
-                  <div>
-                    {requests.map((request,index) => (
-                      <div key={index}>
-                        <p>{request.method}</p>
-                        <button onClick={() => this.setState({payload: request}) }>Sign</button>
-                      </div>
-                    ))}
-                  </div>
-                )
-              ) : (
-                <div>
-                  this is payload
-                </div>
-              )}
-            </>
           )
-        }
+        ) : (
+          <>
+            {/* Show the dApp that is connected */}
+            <h6>{"Connected to"}</h6>
+            <img src={peerMeta.icons[0]} alt={peerMeta.name} />
+            <div>{peerMeta.name}</div>
+            <button onClick={this.killSession}>Disconnect</button>
+            {!payload ? (
+              requests.length !== 0 && (
+                // Show the requests to the connector from connected dApp
+                <div>
+                  {requests.map((request, index) => (
+                    <div key={index}>
+                      <p>{request.method}</p>
+                      <button
+                        onClick={() => {
+                          this.setState({ payload: request });
+                        }}
+                      >
+                        Sign
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )
+            ) : (
+              <Payload payload={payload}/>
+            )}
+          </>
+        )}
         <div></div>
       </>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,7 +339,7 @@ class App extends React.Component<{}> {
                   approveRequest={this.approveRequest}
                   rejectRequest={this.rejectRequest}
                   renderPayload={(payload: any) => getAppConfig().rpcEngine.render(payload)}
-                  state={this.state}
+                  appState={this.state}
                 />
               </>
             )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,7 +269,10 @@ class App extends React.Component<{}> {
                 </div>
               )
             ) : (
-              <Payload payload={payload}/>
+              <>
+                <hr/>
+                <Payload payload={payload}/>
+              </>
             )}
           </>
         )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ export const INITIAL_STATE: IAppState = {
 
 class App extends React.Component<{}> {
   public state: IAppState;
-  
+
   constructor(props: any) {
     super(props);
     this.state = {
@@ -95,7 +95,8 @@ class App extends React.Component<{}> {
     await getAppConfig().events.init(this.state, this.bindedSetState);
   };
 
-  public bindedSetState = (newState: Partial<IAppState>) => this.setState(newState);
+  public bindedSetState = (newState: Partial<IAppState>) =>
+    this.setState(newState);
 
   public subscribeToEvents = () => {
     console.log("ACTION", "subscribeToEvents");
@@ -113,7 +114,7 @@ class App extends React.Component<{}> {
         this.setState({ peerMeta });
       });
 
-      connector.on("session_update", error => {
+      connector.on("session_update", (error) => {
         console.log("EVENT", "session_update");
 
         if (error) {
@@ -130,7 +131,11 @@ class App extends React.Component<{}> {
           throw error;
         }
 
-        await getAppConfig().rpcEngine.router(payload, this.state, this.bindedSetState);
+        await getAppConfig().rpcEngine.router(
+          payload,
+          this.state,
+          this.bindedSetState
+        );
       });
 
       connector.on("connect", (error, payload) => {
@@ -209,19 +214,25 @@ class App extends React.Component<{}> {
     }
   };
 
-
   public render() {
+    const {peerMeta} = this.state;
     return (
       <>
-        <div>
-          {this.state.address}
-        </div>
+        <div>{this.state.address}</div>
         <input onChange={this.onURIPaste} placeholder="Paste wc uri"></input>
+        <br></br>
+        {peerMeta && peerMeta.name && (
+          <>
+            <p>{peerMeta.name}</p>
+            <p>{peerMeta.description}</p>
+            <button>Approve</button>
+            <button>Rejects</button>
+          </>
+        )}
+        <div></div>
       </>
-    )
+    );
   }
-
-
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,6 +338,7 @@ class App extends React.Component<{}> {
                   payload={payload}
                   approveRequest={this.approveRequest}
                   rejectRequest={this.rejectRequest}
+                  renderPayload={(payload: any) => getAppConfig().rpcEngine.render(payload)}
                   state={this.state}
                 />
               </>

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -29,6 +29,7 @@ export class Payload extends React.Component<IPayloadProps, IPayloadStates> {
     this.init();
   }
 
+  // Fetches the formatted object async
   public init = async () => {
     let params;
     const { renderPayload, payload } = this.props;
@@ -42,6 +43,7 @@ export class Payload extends React.Component<IPayloadProps, IPayloadStates> {
     return (
       <>
         {!loading ? (
+          // Render the params of the payload after payload is formatted async
           <div>
             <div>
               {params.map((param) => (
@@ -66,6 +68,7 @@ export class Payload extends React.Component<IPayloadProps, IPayloadStates> {
             </button>
           </div>
         ) : (
+          // Loading state to mount component while it waits for payload to format
           <>Loading transaction info</>
         )}
       </>

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -1,27 +1,30 @@
 import { convertHexToNumber } from "@walletconnect/utils";
 import { formatEther } from "ethers/lib/utils";
 import axios from "axios";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export const Payload = (props: any) => {
     const {payload} = props;
     const [textSig, setTextSig] = useState("");
     
-    // HELPER FUNCTION: get the text equivalent of the transaction function used
-    async function getFunctionType (hexSig: string) {
-        const textSig = await axios
-          .get(
-            `https://www.4byte.directory/api/v1/signatures/?hex_signature=${hexSig}`
-          )
-          .then((response) => {
-            return response.data.results[0].text_signature;
-          })
-          .catch((error) => {
-            throw error;
-          });
-        const resolvedTextSig = await textSig;
-        await setTextSig(resolvedTextSig)
-      };
+    useEffect(() => {
+        // HELPER FUNCTION: get the text equivalent of the transaction function used
+        async function getFunctionType () {
+            const textSig = await axios
+            .get(
+                `https://www.4byte.directory/api/v1/signatures/?hex_signature=${payload.params[0].data.slice(0,9)}`
+            )
+            .then((response) => {
+                return response.data.results[0].text_signature;
+            })
+            .catch((error) => {
+                throw error;
+            });
+            setTextSig(textSig)
+        };
+        getFunctionType();
+    },[payload.params]);
+    
 
     return (
         <div>
@@ -33,6 +36,10 @@ export const Payload = (props: any) => {
             <div>{`Gas: ${formatEther(
                 convertHexToNumber(payload.params[0].gas)
             )}`}</div>
+            <div>{`To: ${payload.params[0].to}`}</div>
+            <br></br>
+            <button>Approve</button>
+            <button>Reject</button>
         </div>
     )
 }

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -1,21 +1,24 @@
-import { convertHexToNumber } from "@walletconnect/utils";
-import { formatEther } from "ethers/lib/utils";
-import axios from "axios";
 import { useState, useEffect } from "react";
 import { IAppState } from "../helpers/types";
-import { BigNumber } from "ethers";
+import { IRequestRenderParams } from "../helpers/types";
+import axios from "axios";
 
 export interface IPayloadProps {
   payload: any;
   approveRequest: () => Promise<void>;
   rejectRequest: () => Promise<void>;
+  renderPayload: (payload: any) => IRequestRenderParams[];
   state: IAppState;
 }
 
 export const Payload = (props: IPayloadProps) => {
   const [textSig, setTextSig] = useState("");
-  const { payload, approveRequest, rejectRequest, state } = props;
+  const { payload, approveRequest, rejectRequest, state, renderPayload } =
+    props;
   console.log(payload);
+
+  const params: IRequestRenderParams[] = renderPayload(payload);
+  console.log(params);
 
   useEffect(() => {
     // HELPER FUNCTION: get the text equivalent of the transaction function used
@@ -37,12 +40,18 @@ export const Payload = (props: IPayloadProps) => {
     }
     getFunctionType();
   }, [payload.params]);
-
+  
   return (
     <div>
       <div>{payload.method}</div>
       <div>{`Function: ${textSig}`}</div>
-      <div>
+      {params.map((param) => (
+        <div key={param.label}>
+          <h4>{param.label}</h4>
+          <p>{param.value}</p>
+        </div>
+      ))}
+      {/* <div>
         {`Value: ${formatEther(BigNumber.from(payload.params[0].value))}`}
       </div>
       <div>
@@ -60,7 +69,7 @@ export const Payload = (props: IPayloadProps) => {
               )
         }`}
       </div>
-      <div>{`To: ${payload.params[0].to}`}</div>
+      <div>{`To: ${payload.params[0].to}`}</div> */}
       <br></br>
       <button onClick={approveRequest} disabled={state.transactionLoading}>
         Approve

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -2,45 +2,72 @@ import { convertHexToNumber } from "@walletconnect/utils";
 import { formatEther } from "ethers/lib/utils";
 import axios from "axios";
 import { useState, useEffect } from "react";
+import { IAppState } from "../helpers/types";
+import { BigNumber } from "ethers";
 
-export const Payload = (props: any) => {
-    const {payload} = props;
-    const [textSig, setTextSig] = useState("");
-    
-    useEffect(() => {
-        // HELPER FUNCTION: get the text equivalent of the transaction function used
-        async function getFunctionType () {
-            const textSig = await axios
-            .get(
-                `https://www.4byte.directory/api/v1/signatures/?hex_signature=${payload.params[0].data.slice(0,9)}`
-            )
-            .then((response) => {
-                return response.data.results[0].text_signature;
-            })
-            .catch((error) => {
-                throw error;
-            });
-            setTextSig(textSig)
-        };
-        getFunctionType();
-    },[payload.params]);
-    
-
-    return (
-        <div>
-            <div>{payload.method}</div>
-            <div>{`Function: ${textSig}`}</div>
-            <div>{`Value: ${formatEther(
-                convertHexToNumber(payload.params[0].value)
-            )}`}</div>
-            <div>{`Gas: ${formatEther(
-                convertHexToNumber(payload.params[0].gas)
-            )}`}</div>
-            <div>{`To: ${payload.params[0].to}`}</div>
-            <br></br>
-            <button>Approve</button>
-            <button>Reject</button>
-        </div>
-    )
+export interface IPayloadProps {
+  payload: any;
+  approveRequest: () => Promise<void>;
+  rejectRequest: () => Promise<void>;
+  state: IAppState;
 }
 
+export const Payload = (props: IPayloadProps) => {
+  const [textSig, setTextSig] = useState("");
+  const { payload, approveRequest, rejectRequest, state } = props;
+  console.log(payload);
+
+  useEffect(() => {
+    // HELPER FUNCTION: get the text equivalent of the transaction function used
+    async function getFunctionType() {
+      const textSig = await axios
+        .get(
+          `https://www.4byte.directory/api/v1/signatures/?hex_signature=${payload.params[0].data.slice(
+            0,
+            9
+          )}`
+        )
+        .then((response) => {
+          return response.data.results[0].text_signature;
+        })
+        .catch((error) => {
+          throw error;
+        });
+      setTextSig(textSig);
+    }
+    getFunctionType();
+  }, [payload.params]);
+
+  return (
+    <div>
+      <div>{payload.method}</div>
+      <div>{`Function: ${textSig}`}</div>
+      <div>
+        {`Value: ${formatEther(BigNumber.from(payload.params[0].value))}`}
+      </div>
+      <div>
+        {`Transaction Fee: ${
+          payload.params[0].gasPrice
+            ? formatEther(
+                BigNumber.from(payload.params[0].gasPrice).mul(
+                  BigNumber.from(payload.params[0].gasLimit)
+                )
+              )
+            : formatEther(
+                BigNumber.from(payload.params[0].maxFeePerGas).mul(
+                  BigNumber.from(payload.params[0].gasLimit)
+                )
+              )
+        }`}
+      </div>
+      <div>{`To: ${payload.params[0].to}`}</div>
+      <br></br>
+      <button onClick={approveRequest} disabled={state.transactionLoading}>
+        Approve
+      </button>
+      <button onClick={rejectRequest} disabled={state.transactionLoading}>
+        Reject
+      </button>
+    </div>
+  );
+};

--- a/src/components/Payload.tsx
+++ b/src/components/Payload.tsx
@@ -1,0 +1,39 @@
+import { convertHexToNumber } from "@walletconnect/utils";
+import { formatEther } from "ethers/lib/utils";
+import axios from "axios";
+import { useState } from "react";
+
+export const Payload = (props: any) => {
+    const {payload} = props;
+    const [textSig, setTextSig] = useState("");
+    
+    // HELPER FUNCTION: get the text equivalent of the transaction function used
+    async function getFunctionType (hexSig: string) {
+        const textSig = await axios
+          .get(
+            `https://www.4byte.directory/api/v1/signatures/?hex_signature=${hexSig}`
+          )
+          .then((response) => {
+            return response.data.results[0].text_signature;
+          })
+          .catch((error) => {
+            throw error;
+          });
+        const resolvedTextSig = await textSig;
+        await setTextSig(resolvedTextSig)
+      };
+
+    return (
+        <div>
+            <div>{payload.method}</div>
+            <div>{`Function: ${textSig}`}</div>
+            <div>{`Value: ${formatEther(
+                convertHexToNumber(payload.params[0].value)
+            )}`}</div>
+            <div>{`Gas: ${formatEther(
+                convertHexToNumber(payload.params[0].gas)
+            )}`}</div>
+        </div>
+    )
+}
+

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ import walletconnectLogo from "./assets/walletconnect-logo.png";
 import { SUPPORTED_CHAINS } from "../constraints/chains";
 import { 
     MAINNET_CHAIN_ID,
+    GOERLI_CHAIN_ID,
     ETH_STANDARD_PATH
  } from "../constraints/default";
 import { IAppConfig } from "../helpers/types";
@@ -10,7 +11,8 @@ import { getRpcEngine } from "../engines";
 const appConfig: IAppConfig = {
   name: "WalletConnect",
   logo: walletconnectLogo,
-  chainId: MAINNET_CHAIN_ID,
+  // Change this to change to testnet
+  chainId: GOERLI_CHAIN_ID,
   derivationPath: ETH_STANDARD_PATH,
   numberOfAccounts: 3,
   colors: {

--- a/src/constraints/default.ts
+++ b/src/constraints/default.ts
@@ -5,4 +5,4 @@ export const MAINNET_CHAIN_ID = 1;
 export const ROPSTEN_CHAIN_ID = 3;
 export const RINKEBY_CHAIN_ID = 4;
 export const GOERLI_CHAIN_ID = 5;
-export const DEFAULT_CHAIN_ID = RINKEBY_CHAIN_ID;
+export const DEFAULT_CHAIN_ID = GOERLI_CHAIN_ID;

--- a/src/controllers/wallet.ts
+++ b/src/controllers/wallet.ts
@@ -108,6 +108,7 @@ export class WalletController {
   public update(chainId: number): ethers.Wallet {
     const firstUpdate = typeof this.wallet === "undefined";
     this.activeChainId = chainId;
+    // fetch the right rpcUrl that is supported by Infura
     const rpcUrl = getChainData(chainId).rpc_url;
     const wallet = this.generateWallet();
     const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
@@ -132,7 +133,15 @@ export class WalletController {
       try {
         tx = await this.wallet.populateTransaction(tx);
         tx.gasLimit = ethers.BigNumber.from(tx.gasLimit).toHexString();
-        tx.gasPrice = ethers.BigNumber.from(tx.gasPrice).toHexString();
+        if (tx.gasPrice) {
+          tx.gasPrice = ethers.BigNumber.from(tx.gasPrice).toHexString();
+        }
+        if (tx.maxFeePerGas) {
+          tx.maxFeePerGas = ethers.BigNumber.from(tx.maxFeePerGas).toHexString();
+        }
+        if (tx.maxPriorityFeePerGas) {
+          tx.maxPriorityFeePerGas = ethers.BigNumber.from(tx.maxPriorityFeePerGas).toHexString();
+        }
         tx.nonce = ethers.BigNumber.from(tx.nonce).toHexString();
       } catch (err) {
         console.error("Error populating transaction", tx, err);

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -1,5 +1,4 @@
 import { signingMethods, convertHexToNumber } from "@walletconnect/utils";
-
 import { IAppState } from "../helpers/types";
 import { apiGetCustomRequest } from "../helpers/api";
 import { convertHexToUtf8IfPossible } from "../helpers/utilities";

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -1,6 +1,6 @@
 import { signingMethods, convertHexToNumber } from "@walletconnect/utils";
 
-import { IAppState } from "../App";
+import { IAppState } from "../helpers/types";
 import { apiGetCustomRequest } from "../helpers/api";
 import { convertHexToUtf8IfPossible } from "../helpers/utilities";
 import { IRequestRenderParams, IRpcEngine } from "../helpers/types";

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -63,15 +63,16 @@ async function getFunctionType(data: string) {
 
 // Format the request parameters
 // RETURN IRequestRenderParams: a formatted set of parameters of the request
-export function renderEthereumRequests(payload: any): IRequestRenderParams[] {
+export async function renderEthereumRequests(payload: any) {
   let params = [{ label: "Method", value: payload.method }];
+  const textSig = await getFunctionType(payload.params[0].data)
 
   switch (payload.method) {
     case "eth_sendTransaction":
     case "eth_signTransaction":
       params = [
         ...params,
-        { label: "Method", value: getFunctionType(payload.params[0].data)},
+        { label: "textSig", value: textSig},
         { label: "From", value: payload.params[0].from },
         { label: "To", value: payload.params[0].to },
         payload.params[0].gasLimit && {

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -5,6 +5,8 @@ import { convertHexToUtf8IfPossible } from "../helpers/utilities";
 import { IRequestRenderParams, IRpcEngine } from "../helpers/types";
 import { getAppControllers } from "../controllers";
 
+// Specify what kind of request method is accepted by this RPC
+// RETURN boolean: whether the request can be served by this RPC
 export function filterEthereumRequests(payload: any) {
   return (
     payload.method.startsWith("eth_") ||
@@ -15,6 +17,8 @@ export function filterEthereumRequests(payload: any) {
   );
 }
 
+// Determine the right RPC method to process the request
+// RETURN none: add the request with the right RPC method to the app state 
 export async function routeEthereumRequests(payload: any, state: IAppState, setState: any) {
   if (!state.connector) {
     return;
@@ -40,6 +44,8 @@ export async function routeEthereumRequests(payload: any, state: IAppState, setS
   }
 }
 
+// Format the request parameters
+// RETURN IRequestRenderParams: a formatted set of parameters of the request
 export function renderEthereumRequests(payload: any): IRequestRenderParams[] {
   let params = [{ label: "Method", value: payload.method }];
 
@@ -104,6 +110,8 @@ export function renderEthereumRequests(payload: any): IRequestRenderParams[] {
   return params;
 }
 
+// Sign the request, using the sign functions (depending on the request method) in the wallet, powered by ethers.js
+// RETURN none
 export async function signEthereumRequests(payload: any, state: IAppState, setState: any) {
   const { connector, address, chainId } = state;
 
@@ -170,6 +178,7 @@ export async function signEthereumRequests(payload: any, state: IAppState, setSt
     }
 
     if (result) {
+      // Approve the request for WalletConnect
       connector.approveRequest({
         id: payload.id,
         result,
@@ -182,6 +191,7 @@ export async function signEthereumRequests(payload: any, state: IAppState, setSt
       if (!getAppControllers().wallet.isActive()) {
         message = "No Active Account";
       }
+      // Reject the request for WalletConnect
       connector.rejectRequest({
         id: payload.id,
         error: { message },

--- a/src/engines/ethereum.ts
+++ b/src/engines/ethereum.ts
@@ -47,7 +47,7 @@ export async function routeEthereumRequests(payload: any, state: IAppState, setS
   }
 }
 
-async function getFunctionType(data: string) {
+async function getFunctionType(data: string): Promise<string> {
   const textSig = await axios
     .get(
       `https://www.4byte.directory/api/v1/signatures/?hex_signature=${data.slice(0,9)}`
@@ -58,13 +58,15 @@ async function getFunctionType(data: string) {
     .catch((error) => {
       throw error;
     });
+  // TODO: translate textSig to human-readable names
   return textSig;
 }
 
 // Format the request parameters
-// RETURN IRequestRenderParams: a formatted set of parameters of the request
-export async function renderEthereumRequests(payload: any) {
+// RETURN IRequestRenderParams[]: a formatted set of parameters of the request
+export async function renderEthereumRequests(payload: any): Promise<IRequestRenderParams[]> {
   let params = [{ label: "Method", value: payload.method }];
+  // translate the function hash to text equivalent using an API
   const textSig = await getFunctionType(payload.params[0].data)
 
   switch (payload.method) {

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -1,5 +1,5 @@
 import { IRpcEngine } from "../helpers/types";
-import { IAppState } from "../App";
+import { IAppState } from "../helpers/types";
 import ethereum from "./ethereum";
 
 class RpcEngine implements IRpcEngine {

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -7,27 +7,33 @@ class RpcEngine implements IRpcEngine {
     this.engines = engines;
   }
 
+  // Return the filter transaction function of the specific engine to handle the request
   public filter(payload: any) {
     const engine = this.getEngine(payload);
     return engine.filter(payload);
   }
 
+  // Return the route transaction function of the specific engine to handle the request
   public router(payload: any, state: IAppState, setState: any) {
     const engine = this.getEngine(payload);
     return engine.router(payload, state, setState);
   }
 
+  // Return the render transaction function of the specific engine to handle the request
   public render(payload: any) {
     const engine = this.getEngine(payload);
     return engine.render(payload);
   }
 
+  // Return the sign transaction function of the specific engine to handle the request
   public signer(payload: any, state: IAppState, setState: any) {
     const engine = this.getEngine(payload);
     return engine.signer(payload, state, setState);
   }
 
+  // Get the rpcEngine that can handle the request parsed
   private getEngine(payload: any) {
+    // Check if there is any rpc engine that can handle the request, using the filter function of the engines
     const match = this.engines.filter(engine => engine.filter(payload));
     if (!match || !match.length) {
       throw new Error(`No RPC Engine found to handle payload with method ${payload.method}`);

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -1,5 +1,4 @@
-import { IRpcEngine } from "../helpers/types";
-import { IAppState } from "../helpers/types";
+import { IRpcEngine, IAppState } from "../helpers/types";
 import ethereum from "./ethereum";
 
 class RpcEngine implements IRpcEngine {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -60,6 +60,7 @@ export interface IAppState {
     loading: boolean;
     scanner: boolean;
     connector: WalletConnect | null;
+    transactionLoading: boolean;
     uri: string;
     peerMeta: {
         description: string;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,5 +1,5 @@
 import { IJsonRpcRequest } from "@walletconnect/types";
-import { IAppState } from "../App";
+import WalletConnect from "@walletconnect/client";
 
 export interface IAssetData {
     symbol: string;
@@ -55,3 +55,23 @@ export interface IAppConfig {
     rpcEngine: IRpcEngine;
     events: IAppEvents;
   }
+
+export interface IAppState {
+    loading: boolean;
+    scanner: boolean;
+    connector: WalletConnect | null;
+    uri: string;
+    peerMeta: {
+        description: string;
+        url: string;
+        icons: string[];
+        name: string;
+        ssl: boolean;
+    };
+    connected: boolean;
+    chainId: number;
+    address: string;
+    requests: any[];
+    results: any[];
+    payload: any;
+}

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -27,15 +27,13 @@ export interface IAppEvents {
 
 export interface IRequestRenderParams {
     label: string;
-    // value: string | Promise<any>;
     value: string;
 }
 
 export interface IRpcEngine {
     filter: (payload: IJsonRpcRequest) => boolean;
     router: (payload: IJsonRpcRequest, state: IAppState, setState: any) => Promise<void>;
-    render: (payload: IJsonRpcRequest) => Promise<any>;
-    // render: (payload: IJsonRpcRequest) => IRequestRenderParams[];
+    render: (payload: IJsonRpcRequest) => Promise<IRequestRenderParams[]>;
     signer: (payload: IJsonRpcRequest, state: IAppState, setState: any) => Promise<void>;
 }
 

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -27,13 +27,15 @@ export interface IAppEvents {
 
 export interface IRequestRenderParams {
     label: string;
-    value: string | Promise<any>;
+    // value: string | Promise<any>;
+    value: string;
 }
 
 export interface IRpcEngine {
     filter: (payload: IJsonRpcRequest) => boolean;
     router: (payload: IJsonRpcRequest, state: IAppState, setState: any) => Promise<void>;
-    render: (payload: IJsonRpcRequest) => IRequestRenderParams[];
+    render: (payload: IJsonRpcRequest) => Promise<any>;
+    // render: (payload: IJsonRpcRequest) => IRequestRenderParams[];
     signer: (payload: IJsonRpcRequest, state: IAppState, setState: any) => Promise<void>;
 }
 

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -27,7 +27,7 @@ export interface IAppEvents {
 
 export interface IRequestRenderParams {
     label: string;
-    value: string;
+    value: string | Promise<any>;
 }
 
 export interface IRpcEngine {


### PR DESCRIPTION
## PR Description
In this PR, I implemented functions to open a connection with dApps using `WalletConnect`, and then sign requests using the club wallet.

WalletConnect will instantiate a new connector based on the WalletConnect URI provided. The connector will listen to requests. The Ethereum engine (#1) I implemented will route the request to the right method to sign the request. 

## UI
![Screenshot 2022-10-04 at 5 41 50 PM](https://user-images.githubusercontent.com/15060312/193923256-c8f71268-a466-4eed-85ab-f5e7d552abd0.png)
